### PR TITLE
also fetch prs to which you are assigned

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - **🪄 Linkify** — Click **🪄 Linkify** to resolve bare GitHub URLs to titled markdown links. Updates the log in-place.
 - **📊 Work Log Summary** — Generate AI-powered summaries of your work logs for daily standups or weekly reports. Choose the AI model, pick a date range, and **save summaries** directly to your repo in `summaries/`.
 - **✅ TODO List** — Manual TODOs with inline editing + AI-suggested action items based on your work log.
-- **🔀 My PRs** — Live feed of your open PRs in your GitHub org with status badges: **Draft**, **Queued** / **Merging** (merge queue), **CI Failing** (required checks only), **Needs Review** (awaiting human review), and **unanswered comment count** (excludes bots and resolved threads). Click the insert button on any PR to paste its link at the cursor in your work log.
+- **🔀 My PRs** — Live feed of your open PRs (authored or assigned) in your GitHub org with status badges: **Draft**, **Queued** / **Merging** (merge queue), **CI Failing** (required checks only), **Needs Review** (awaiting human review), and **unanswered comment count** (excludes bots and resolved threads). Click the insert button on any PR to paste its link at the cursor in your work log.
 - **🔔 Notifications** — Filtered GitHub notifications: reviews requested, mentions, assignments, and activity on your issues/PRs. Click the insert button to paste a link at the cursor.
 - **🚀 Auto-commit & Push** — Hourly auto-commit of your logs and TODOs to a git repo, with push to remote.
 - **⚙️ Settings** — Ignore noisy repos in notifications.


### PR DESCRIPTION
I noticed that PRs to which one is assigned (like those opened by Copilot), didn't appear in the PRs pane.

I'm not 100% certain if there is a cleaner way to do this but this seems to do the trick